### PR TITLE
Update the allowed rails and pg gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source 'https://rubygems.org'
 
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '>= 5.0.0.racecar1', '< 5.1'
+gem 'rails', '~> 5.1.0'
 # Use postgresql as the database for Active Record
-gem "pg", "~>0.18.2", :require => false
+gem "pg", "~> 1.0", :require => false
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder


### PR DESCRIPTION
Now that inventory_refresh gem has relaxed the required version of rails and pg we can bump this up to newer versions.

Tested running persister and query-api rails server.